### PR TITLE
Use `datalad_catalog.schema_utils` instead of local duplicate code

### DIFF
--- a/README.org
+++ b/README.org
@@ -21,12 +21,14 @@ The key scripts are:
   you can use [[https://github.com/sfb1451/tabby-to-catalog-demo/blob/main/config.json][this one]].
 - Some terms are resolved with API queries, done with simple requests and cached using requests_cache
 
-* Requirements
+* Install Requirements
 
-In lieu of a proper requirements file:
-- dev version of datalad-tabby
-- dev version of datalad-catalog with [[https://github.com/datalad/datalad-catalog/issues/331][#331]] patched by adding an "else" statement
-- pyld, requests_cache
+```
+python -m venv /tmp/my_env
+source /tmp/my_env/bin/activate
+
+pip install requirements-devel.txt
+```
 
 * Workflow - rough overview
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,0 +1,4 @@
+datalad-tabby @ git+https://github.com/psychoinformatics-de/datalad-tabby.git@main
+datalad-catalog @ git+https://github.com/datalad/datalad-catalog.git@main
+pyld
+requests_cache


### PR DESCRIPTION
For context, see: https://github.com/datalad/datalad-catalog/pull/378

This PR:
- Closes https://github.com/sfb1451/tabby-utils/issues/8
- Removes duplicate code for creating base structures for `datalad-catalog`-compatible metadata items, and imports this functionality from `datalad_catalog.schema_utils` instead.
- Adds requirements explicitly to `requirements-devel.txt`

Tested successfully locally on the penguin data.