### PR TITLE
Updates to allow linked data rendering

### DIFF
--- a/conventions/tby-crc1451v0/dataset.ctx.jsonld
+++ b/conventions/tby-crc1451v0/dataset.ctx.jsonld
@@ -7,6 +7,7 @@
   "dpv": "https://w3id.org/dpv#",
   "author": "schema:author",
   "citation": "schema:citation",
+  "crc-project": "schema:ResearchProject",
   "data-controller": "dpv:hasDataController",
   "description": "schema:description",
   "doi": "bibo:doi",
@@ -19,6 +20,8 @@
   "license": "schema:license",
   "name": "schema:name",
   "publication": "schema:citation",
+  "sample[organism]": "obo:UBERON_0000468",
+  "sample[organism-part]": "obo:UBERON_0000475",
   "title": "schema:title",
   "used-for": "prov:hadUsage",
   "version": "schema:version"


### PR DESCRIPTION
This PR:
- updates the tabby convention, specifically the context for `dataset` to include definitions for previously undefined terms (see https://github.com/sfb1451/tabby-utils/issues/10)
- updates `load_tabby` to also include the `additional_display_definitions` in a generated catalog record. this allows definitions of terms in the `additional_display` field to flow through to the catalog such that they can be rendered as rich linked data in the catalog (see https://github.com/psychoinformatics-de/sfb1451-projects-catalog/issues/41)
- addresses https://github.com/psychoinformatics-de/sfb1451-projects-catalog/issues/41 to an extent, but not for all defined fields in the dataset record
- was tested successfully locally with the sample penguin data

Important:
- The catalog to which the resulting metadata records are added should have the patch introduced in https://github.com/datalad/datalad-catalog/commit/30773cb8797c39cf963f3a147cc51b9f79df0056 (suggested approach would be to checkout `sfb1451` branch)
- `load_tabby.py` should be executed again once this PR is merged in order to generate metadata records with the desired content
