### PR TITLE
Communicate semantic information in a different way

### DIFF
--- a/conventions/tby-crc1451v0/dataset.ctx.jsonld
+++ b/conventions/tby-crc1451v0/dataset.ctx.jsonld
@@ -2,6 +2,7 @@
   "bibo": "https://purl.org/ontology/bibo/",
   "dcterms": "https://purl.org/dc/terms/",
   "obo": "https://purl.obolibrary.org/obo/",
+  "openminds": "https://openminds.ebrains.eu/controlledTerms/",
   "prov": "http://www.w3.org/ns/prov#",
   "schema": "https://schema.org/",
   "dpv": "https://w3id.org/dpv#",
@@ -20,8 +21,8 @@
   "license": "schema:license",
   "name": "schema:name",
   "publication": "schema:citation",
-  "sample[organism]": "obo:UBERON_0000468",
-  "sample[organism-part]": "obo:UBERON_0000475",
+  "sample[organism]": "openminds:Species",
+  "sample[organism-part]": "openminds:UBERONParcellation",
   "title": "schema:title",
   "used-for": "prov:hadUsage",
   "version": "schema:version"

--- a/load_tabby.py
+++ b/load_tabby.py
@@ -230,6 +230,7 @@ cat_context = {
     "dcterms": "https://purl.org/dc/terms/",
     "nfo": "https://www.semanticdesktop.org/ontologies/2007/03/22/nfo/#",
     "obo": "https://purl.obolibrary.org/obo/",
+    "openminds": "https://openminds.ebrains.eu/controlledTerms/",
     "name": "schema:name",
     "title": "schema:title",
     "description": "schema:description",
@@ -275,8 +276,8 @@ cat_context = {
         },
     },
     "sfbProject": "schema:ResearchProject",
-    "sfbSampleOrganism": "obo:UBERON_0000468",
-    "sfbSamplePart": "obo:UBERON_0000475",
+    "sfbSampleOrganism": "openminds:Species",
+    "sfbSamplePart": "openminds:UBERONParcellation",
 }
 
 parser = ArgumentParser()

--- a/load_tabby.py
+++ b/load_tabby.py
@@ -218,7 +218,9 @@ def process_homepage(homepage):
     linked data scenarios.
 
     """
-    if isinstance(homepage, list):
+    if homepage is None:
+        return None
+    elif isinstance(homepage, list):
         return [process_homepage(hp) for hp in homepage]
     else:
         return {"@type": "https://schema.org/URL", "@value": homepage}


### PR DESCRIPTION
With these changes, the additional content (additional display) will be provided to the catalog as an object with `@context` that defines properties, and `@type` annotation on objects where possible. Closes #14 

Catalog tuning to accept this kind of input is in https://github.com/psychoinformatics-de/sfb1451-projects-catalog/pull/62