### PR TITLE
Return funding templates as schema.org grants

### DIFF
--- a/load_tabby.py
+++ b/load_tabby.py
@@ -176,7 +176,8 @@ def process_funding(funding, lookup={}):
                     parentgrant = None
             else:
                 # DFG but not SFB1451, only edit identifier
-                grant["identifier"] = f"https://gepris.dfg.de/gepris/projekt/{grant.get(identifier)}"
+                project = grant.get("identifier")
+                grant["identifier"] = f"https://gepris.dfg.de/gepris/projekt/{project}"
 
         if parentgrant is not None:
             grant_list.append(parentgrant)

--- a/load_tabby.py
+++ b/load_tabby.py
@@ -108,8 +108,18 @@ def process_publications(publications):
 
 
 def process_funding(funding):
-    """Ensure that funding is an array"""
-    # return [funding] if isinstance(funding, dict) else funding
+    """Edit funding item(s), return an array
+
+    Ensure that funding is an array. Edit DFG funding to spell out
+    Deutsche Forschungsgemeinschaft and build a gepris url from the
+    identifier. For SFB1451, populate additional fields based on the
+    identifier (assuming 431549029-<project> format).
+
+    Each funding element will have a @type: https://schema.org/Grant,
+    so that we can apply custom rules in catalog template.
+
+    """
+
     if isinstance(funding, dict):
         funding = [funding]
 
@@ -125,6 +135,9 @@ def process_funding(funding):
                 grant["identifier"] = f"https://gepris.dfg.de/gepris/projekt/{project}"
             else:
                 grant["identifier"] = f"https://gepris.dfg.de/gepris/projekt/{grant.get(identifier)}"
+
+        # replace compact IRI with a full IRI
+        grant["@type"] = grant.get("@type", "").replace("schema:", "https://schema.org/")
 
         grant_list.append(grant)
 
@@ -316,7 +329,6 @@ record = load_tabby(
 
 expanded = jsonld.expand(record)
 compacted = jsonld.compact(record, ctx=cat_context)
-pprint(compacted.get("funding"))
 
 # Use catalog schema_utils to get base structure of metadata item
 meta_item = get_metadata_item(

--- a/load_tabby.py
+++ b/load_tabby.py
@@ -109,8 +109,26 @@ def process_publications(publications):
 
 def process_funding(funding):
     """Ensure that funding is an array"""
-    return [funding] if isinstance(funding, dict) else funding
+    # return [funding] if isinstance(funding, dict) else funding
+    if isinstance(funding, dict):
+        funding = [funding]
 
+    grant_list = []
+    for f in funding:
+        grant = f.copy()
+        if grant.get("funder") == "DFG":
+            grant["funder"] = "Deutsche Forschungsgemeinschaft (DFG)"
+            if grant.get("identifier").startswith("431549029-"):
+                project, _, subproject = grant.get("identifier").rpartition("-")
+                grant["name"] = "SFB 1451: Key mechanisms of motor control in health and disease"
+                grant["alternateName"] = f"SFB 1451 ({project}, {subproject} project)"
+                grant["identifier"] = f"https://gepris.dfg.de/gepris/projekt/{project}"
+            else:
+                grant["identifier"] = f"https://gepris.dfg.de/gepris/projekt/{grant.get(identifier)}"
+
+        grant_list.append(grant)
+
+    return grant_list
 
 def process_keywords(keywords):
     """Ensure that keywords are an array"""
@@ -249,7 +267,7 @@ cat_context = {
     "funding": {
         "@id": "schema:funding",
         "@context": {
-            "name": "schema:funder",
+            "funder": "schema:funder",
             "identifier": "schema:identifier",
         },
     },
@@ -298,6 +316,7 @@ record = load_tabby(
 
 expanded = jsonld.expand(record)
 compacted = jsonld.compact(record, ctx=cat_context)
+pprint(compacted.get("funding"))
 
 # Use catalog schema_utils to get base structure of metadata item
 meta_item = get_metadata_item(

--- a/lookup_tables.toml
+++ b/lookup_tables.toml
@@ -1,0 +1,95 @@
+[funding]
+
+[funding.sfb1451]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "SFB 1451: Key mechanisms of motor control in health and disease"
+identifier = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.A01]
+name = "Understanding plastin 3 and its interactors in motor neuron function and plasticity in health and disease"
+identifier = "https://gepris.dfg.de/gepris/projekt/458620544"
+
+[funding.A02]
+name = "Dysregulation of the autophagy-endolysosomal system as a putative pathological mechanism behind the motor control dysfunction"
+identifier = "https://gepris.dfg.de/gepris/projekt/458627899"
+
+[funding.A03]
+name = "Motor learning-induced plasticity of cerebellar Purkinje neuron connectivity"
+identifier = "https://gepris.dfg.de/gepris/projekt/458628816"
+
+[funding.A04]
+name = "The role of the reward system in obesity- and ageing-associated changes of motor behaviours"
+identifier = "https://gepris.dfg.de/gepris/projekt/458630481"
+
+[funding.A05]
+name = "Neural mechanisms underlying motor flexibility in fruit fly walking"
+identifier = "https://gepris.dfg.de/gepris/projekt/458631052"
+
+[funding.A06]
+name = "Sensory-motor pathways controlling voluntary movements in health and disease"
+identifier = "https://gepris.dfg.de/gepris/projekt/458633663"
+
+[funding.A07]
+name = "Role of synaptic lipid modulated cortical excitability in motor control"
+identifier = "https://gepris.dfg.de/gepris/projekt/470703892"
+
+[funding.B01]
+name = "Developmental mechanisms affecting motor skills and motor control"
+identifier = "https://gepris.dfg.de/gepris/projekt/458636148"
+
+[funding.B02]
+name = "Neural network maturation underlying top-down motor control and movement initiation in childhood and adolescence"
+identifier = "https://gepris.dfg.de/gepris/projekt/458637144"
+
+[funding.B03]
+name = "Modelling neural network dynamics underlying movements in health and disease"
+identifier = "https://gepris.dfg.de/gepris/projekt/458638358"
+
+[funding.B04]
+name = "Motor control under uncertainty in the healthy human brain"
+identifier = "https://gepris.dfg.de/gepris/projekt/458639706"
+
+[funding.B05]
+name = "Single-case predictions of motor abilities in health and disease"
+identifier = "https://gepris.dfg.de/gepris/projekt/458640473"
+
+[funding.C01]
+name = "Identification and selective stimulation of motor recovery-related functional networks after experimental stroke"
+identifier = "https://gepris.dfg.de/gepris/projekt/458642074"
+
+[funding.C03]
+name = "Striatal dopamine and volitional motor control: vigour, planning, and incentive salience "
+identifier = "https://gepris.dfg.de/gepris/projekt/458646297"
+
+[funding.C04]
+name = "Apraxia in Alzheimer’s disease: Plastic reorganization of praxis networks in response to chronically progressive dysfunction"
+identifier = "https://gepris.dfg.de/gepris/projekt/458674749"
+
+[funding.C05]
+name = "Reorganisation of the motor system following stroke"
+identifier = "https://gepris.dfg.de/gepris/projekt/458684554"
+
+[funding.C06]
+name = "Major depression as a transient functional lesion model of motor control"
+identifier = "https://gepris.dfg.de/gepris/projekt/458685554"
+
+[funding.C07]
+name = "Neural networks underlying motor tic formation and suppression"
+identifier = "https://gepris.dfg.de/gepris/projekt/458687122"
+
+[funding.INF]
+name = "Data Managment"
+identifier = "https://gepris.dfg.de/gepris/projekt/458705875"
+
+[funding.Z01]
+name = "Central Office"
+identifier = "https://gepris.dfg.de/gepris/projekt/458691909"
+
+[funding.Z02]
+name = "Animal Motor Core Facility"
+identifier = "https://gepris.dfg.de/gepris/projekt/458701226"
+
+[funding.Z03]
+name = "Humanes Motor-Assesment Center"
+identifier = "https://gepris.dfg.de/gepris/projekt/458705014"


### PR DESCRIPTION
This is a rethinking of the funding item to make it better aligned with https://schema.org/Grant

Most notably, and in contrast with the catalog schema, `name` now means the grant name, not the funder name (which is now returned as `funder`). We also do some special handling to the SFB1451 funding declaration, turning it from what we [requested  in the rdm docs](https://rdm.sfb1451.de/data-catalog-submission/#table-funding-required) (funder: `DFG`, grant: `431549029-<CRC-project-code>`) to a representation containing a name (project title), alternate name (recommended acknowledgement), and gepris URL.

Such grant items are annotated with `@type = https://schema.org/Grant` so that we can show them on a custom card in the SFB catalog.